### PR TITLE
Allow Mahakam server reachability to cluster network by adding secondary IP

### DIFF
--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -27,9 +27,10 @@ const (
 	HelmControllerDefaultWaitTimeout = 300
 	HelmDefaultChartValuesDirectory  = "/opt/mahakamcloud/chartvalues/"
 
-	// Default mahakam config path to store multiple kubeconfig files
-	MahakamMultiKubeconfigPath = "/opt/mahakamcloud/clusters"
-	MahakamSSHPrivateKeyPath   = "/root/.ssh/id_rsa"
+	// Default mahakam config
+	MahakamMultiKubeconfigPath     = "/opt/mahakamcloud/clusters"
+	MahakamSSHPrivateKeyPath       = "/root/.ssh/id_rsa"
+	MahakamDefaultNetworkInterface = "ens3"
 
 	// Default terraform config
 	TerraformDefaultDirectory = "/opt/mahakamcloud/terraform/"

--- a/pkg/handlers/create_network.go
+++ b/pkg/handlers/create_network.go
@@ -133,13 +133,18 @@ func newCreateNetworkWF(cluster *models.Network, cHandler *CreateNetwork) (*crea
 func (cn *createNetworkWF) Run() error {
 	cn.log.Infof("running create network workflow: %v", cn)
 
-	n, err := cn.handlers.Network.AllocateClusterNetwork()
+	pretasks, err := cn.getPreCreateTask()
 	if err != nil {
-		cn.log.Errorf("cluster network allocation failed %v: %s", cn, err)
 		return err
 	}
-	cn.log.Infof("cluster network has been allocated %v", n)
-	cn.clusterNetwork = n
+
+	// blocking pre-create tasks
+	for _, t := range pretasks {
+		cn.log.Infof("running pre-create task %v", t)
+		if err := t.Run(); err != nil {
+			cn.log.Errorf("error running pre-create task %v: %s", t, err)
+		}
+	}
 
 	tasks, err := cn.getCreateTask()
 	if err != nil {
@@ -156,6 +161,34 @@ func (cn *createNetworkWF) Run() error {
 	}(tasks)
 
 	return nil
+}
+
+func (cn *createNetworkWF) getPreCreateTask() ([]task.Task, error) {
+	cn.log.Debugf("getting pre-create task for network %s", cn.clusterNetwork.Name)
+
+	n, err := cn.handlers.Network.AllocateClusterNetwork()
+	if err != nil {
+		cn.log.Errorf("cluster network allocation failed %v: %s", cn, err)
+		return nil, err
+	}
+	cn.log.Infof("cluster network has been allocated %v", n)
+	cn.clusterNetwork = n
+
+	var tasks []task.Task
+	tasks = cn.setupNetworkPreCreateTasks(tasks)
+	return tasks, nil
+}
+
+func (cn *createNetworkWF) setupNetworkPreCreateTasks(tasks []task.Task) []task.Task {
+	cn.log.Debugf("setup network pre-create tasks for network %s", cn.clusterNetwork.Name)
+
+	mahakamServerIP := cn.clusterNetwork.MahakamServer
+	mahakamServerMask := cn.clusterNetwork.ClusterNetworkCIDR.Mask
+	mahakamNetIf := config.MahakamDefaultNetworkInterface
+
+	networkReachability := provisioner.NewClusterNetworkReachability(utils.NewIPUtil(), mahakamServerIP, mahakamServerMask, mahakamNetIf)
+	tasks = append(tasks, networkReachability)
+	return tasks
 }
 
 func (cn *createNetworkWF) getCreateTask() ([]task.Task, error) {

--- a/pkg/handlers/create_network.go
+++ b/pkg/handlers/create_network.go
@@ -186,6 +186,10 @@ func (cn *createNetworkWF) setupNetworkPreCreateTasks(tasks []task.Task) []task.
 	mahakamServerMask := cn.clusterNetwork.ClusterNetworkCIDR.Mask
 	mahakamNetIf := config.MahakamDefaultNetworkInterface
 
+	// This is required to allow reachability from mahakam server to cluster network by assigning
+	// mahakam server with secondary IP from cluster network as per current flat network topology. Depending
+	// on network topology, when mahakam server can reach cluster network via DC routing or alike at infra level,
+	// this will go away.
 	networkReachability := provisioner.NewClusterNetworkReachability(utils.NewIPUtil(), mahakamServerIP, mahakamServerMask, mahakamNetIf)
 	tasks = append(tasks, networkReachability)
 	return tasks

--- a/pkg/handlers/create_network.go
+++ b/pkg/handlers/create_network.go
@@ -164,7 +164,7 @@ func (cn *createNetworkWF) Run() error {
 }
 
 func (cn *createNetworkWF) getPreCreateTask() ([]task.Task, error) {
-	cn.log.Debugf("getting pre-create task for network %s", cn.clusterNetwork.Name)
+	cn.log.Debugf("getting pre-create task for network workflow")
 
 	n, err := cn.handlers.Network.AllocateClusterNetwork()
 	if err != nil {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -140,6 +140,7 @@ type ClusterNetwork struct {
 	Gateway            net.IP
 	Nameserver         net.IP
 	Dhcp               net.IP
+	MahakamServer      net.IP
 }
 
 // NewClusterNetwork returns a new ClusterNetwork
@@ -148,6 +149,7 @@ func NewClusterNetwork(cidr net.IPNet, nm *NetworkManager) *ClusterNetwork {
 	gatewayIP := getGatewayIP(cidr)
 	nameserverIP := getNameserverIP(cidr)
 	dhcpIP := getDHCPIP(cidr)
+	mahakamServerIP := getMahakamServerIP(cidr)
 
 	return &ClusterNetwork{
 		NetworkManager:     nm,
@@ -156,6 +158,7 @@ func NewClusterNetwork(cidr net.IPNet, nm *NetworkManager) *ClusterNetwork {
 		Gateway:            gatewayIP,
 		Nameserver:         nameserverIP,
 		Dhcp:               dhcpIP,
+		MahakamServer:      mahakamServerIP,
 	}
 }
 
@@ -230,4 +233,13 @@ func getDHCPIP(cidr net.IPNet) net.IP {
 	// Reserved IPs for main network components in cluster network
 	dhcp[3] = byte(2)
 	return dhcp
+}
+
+func getMahakamServerIP(cidr net.IPNet) net.IP {
+	mahakam := make(net.IP, len(cidr.IP))
+	copy(mahakam, cidr.IP)
+
+	// Reserved IPs for main network components in cluster network
+	mahakam[3] = byte(5)
+	return mahakam
 }

--- a/pkg/provisioner/create_cluster.go
+++ b/pkg/provisioner/create_cluster.go
@@ -149,3 +149,31 @@ func (k *CreateAdminKubeconfig) Run() error {
 	k.log.Infof("admin kubeconfig has been copied over successfully '%v'", k)
 	return nil
 }
+
+type ClusterNetworkReachability struct {
+	ipAssigner        utils.IPAssigner
+	mahakamServerIP   net.IP
+	mahakamServerMask net.IPMask
+	mahakamNetif      string
+	log               logrus.FieldLogger
+}
+
+func NewClusterNetworkReachability(ipAssigner utils.IPAssigner, mahakamServerIP net.IP, mahakamServerMask net.IPMask, mahakamNetif string) *ClusterNetworkReachability {
+	networkReachbilityLog := logrus.WithField("task", fmt.Sprintf("configure reachability from server to cluster network with %s and mask %s on %s", mahakamServerIP, mahakamServerMask, mahakamNetif))
+
+	return &ClusterNetworkReachability{
+		ipAssigner:        ipAssigner,
+		mahakamServerIP:   mahakamServerIP,
+		mahakamServerMask: mahakamServerMask,
+		mahakamNetif:      mahakamNetif,
+		log:               networkReachbilityLog,
+	}
+}
+
+func (c *ClusterNetworkReachability) Run() error {
+	_, err := c.ipAssigner.Assign(c.mahakamServerIP, c.mahakamServerMask, c.mahakamNetif)
+	if err != nil {
+		return fmt.Errorf("error assigning cluster network IP to mahakam server: %s", err)
+	}
+	return nil
+}

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/mahakamcloud/mahakam/pkg/cmd_runner"
+)
+
+type IPAssigner interface {
+	Assign(ip net.IP, mask net.IPMask, netif string) (string, error)
+}
+
+type IPUtil struct {
+	runner cmd_runner.CmdRunner
+}
+
+func NewIPUtil() *IPUtil {
+	runner := cmd_runner.New()
+	return &IPUtil{
+		runner: runner,
+	}
+}
+
+func (i *IPUtil) Assign(ip net.IP, mask net.IPMask, netif string) (string, error) {
+	ones, _ := mask.Size()
+	ipaddr := ip.String() + "/" + strconv.Itoa(ones)
+	args := []string{"addr", "add", ipaddr, "dev", netif}
+	return i.runner.CombinedOutput("ip", args...)
+}


### PR DESCRIPTION
As per current network topology, Mahakam server cannot reach the newly provisioned cluster network without getting assigned IP from the cluster network. This PR assigns server the cluster network IP as secondary IP.