### PR TITLE
Rewrite and simplify Mahakam server main function

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,12 +11,13 @@ import (
 
 // Config represents mahakam configuration
 type Config struct {
-	KVStoreConfig    StorageBackendConfig `yaml:"storage_backend"`
-	NetworkConfig    NetworkConfig        `yaml:"network"`
-	KubernetesConfig KubernetesConfig     `yaml:"kubernetes"`
-	GateConfig       GateConfig           `yaml:"gate"`
-	TerraformConfig  TerraformConfig      `yaml:"terraform"`
-	HostsConfig      []Host               `yaml:"hosts"`
+	MahakamServerConfig MahakamServerConfig  `yaml:"server"`
+	KVStoreConfig       StorageBackendConfig `yaml:"storage_backend"`
+	NetworkConfig       NetworkConfig        `yaml:"network"`
+	KubernetesConfig    KubernetesConfig     `yaml:"kubernetes"`
+	GateConfig          GateConfig           `yaml:"gate"`
+	TerraformConfig     TerraformConfig      `yaml:"terraform"`
+	HostsConfig         []Host               `yaml:"hosts"`
 }
 
 // LoadConfig loads a configuration file
@@ -44,6 +45,10 @@ func LoadConfig(configFilePath string) (*Config, error) {
 
 // Validate validates mahakam configuration
 func (c *Config) Validate() error {
+	if err := c.MahakamServerConfig.Validate(); err != nil {
+		return fmt.Errorf("Error validating KV store configuration: %s", err)
+	}
+
 	if err := c.KVStoreConfig.Validate(); err != nil {
 		return fmt.Errorf("Error validating KV store configuration: %s", err)
 	}
@@ -68,6 +73,20 @@ func (c *Config) Validate() error {
 		if err := host.Validate(); err != nil {
 			return fmt.Errorf("Error validating hosts configuration: %s", err)
 		}
+	}
+
+	return nil
+}
+
+// MahakamServerConfig stores mahakam server config
+type MahakamServerConfig struct {
+	Address string `yaml:"address"`
+	Port    int    `yaml:"port"`
+}
+
+func (m *MahakamServerConfig) Validate() error {
+	if m.Port == 0 {
+		return fmt.Errorf("Must provide non-empty port")
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -12,6 +12,10 @@ import (
 
 var (
 	validConfig = Config{
+		MahakamServerConfig: MahakamServerConfig{
+			Address: "fake-server-address",
+			Port:    1234,
+		},
 		KVStoreConfig: StorageBackendConfig{
 			BackendType: "fake-storage-backend-type",
 			Address:     "fake-storage-backend-address",

--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -11,8 +11,7 @@ const (
 	ResourceOwnerMahakam = "mahakam"
 
 	// Mahakam API server config
-	MahakamAPIBasePath    = "/v1"
-	MahakamAPIDefaultPort = 9000
+	MahakamAPIBasePath = "/v1"
 
 	// Custom path for storing resource in kvstore
 	KeyPathMahakam       = "mahakamcloud/"

--- a/pkg/config/example/config.sample.yaml
+++ b/pkg/config/example/config.sample.yaml
@@ -1,3 +1,6 @@
+server:
+  host: "0.0.0.0"
+  port: 9000
 storage_backend:
   backend_type: "consul"
   address: "127.0.0.1:8500"

--- a/pkg/handlers/create_network.go
+++ b/pkg/handlers/create_network.go
@@ -4,14 +4,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
+	"github.com/mahakamcloud/mahakam/pkg/api/v1/client"
 	netclient "github.com/mahakamcloud/mahakam/pkg/api/v1/client/networks"
 	"github.com/mahakamcloud/mahakam/pkg/api/v1/models"
 	"github.com/mahakamcloud/mahakam/pkg/api/v1/restapi/operations/networks"
-	mahakamclient "github.com/mahakamcloud/mahakam/pkg/client"
 	"github.com/mahakamcloud/mahakam/pkg/config"
 	"github.com/mahakamcloud/mahakam/pkg/network"
 	"github.com/mahakamcloud/mahakam/pkg/node"
@@ -112,7 +111,7 @@ func newCreateNetworkWF(cluster *models.Network, cHandler *CreateNetwork) (*crea
 
 	dcNameserverIP := net.ParseIP(cHandler.AppConfig.NetworkConfig.DatacenterNameserver)
 
-	allocatedPublicIP, err := getPublicIP()
+	allocatedPublicIP, err := getPublicIP(cHandler.Client)
 	if err != nil {
 		return nil, fmt.Errorf("error getting public IP allocation: %s", err)
 	}
@@ -331,9 +330,8 @@ func (cn *createNetworkWF) setupNetworkNameserverTasks(tasks []task.Task) []task
 	return tasks
 }
 
-func getPublicIP() (net.IP, error) {
-	client := mahakamclient.GetMahakamClient(":" + strconv.Itoa(config.MahakamAPIDefaultPort))
-	res, err := client.Networks.AllocateOrReleaseFromIPPool(netclient.NewAllocateOrReleaseFromIPPoolParams().
+func getPublicIP(c *client.Mahakam) (net.IP, error) {
+	res, err := c.Networks.AllocateOrReleaseFromIPPool(netclient.NewAllocateOrReleaseFromIPPoolParams().
 		WithAction(swag.String(config.IPPoolActionAllocate)))
 	if err != nil {
 		return nil, err

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -1,11 +1,16 @@
 package handlers
 
 import (
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/mahakamcloud/mahakam/pkg/api/v1/client"
+	mahakamclient "github.com/mahakamcloud/mahakam/pkg/client"
 	"github.com/mahakamcloud/mahakam/pkg/config"
 	"github.com/mahakamcloud/mahakam/pkg/network"
 	"github.com/mahakamcloud/mahakam/pkg/provisioner"
 	store "github.com/mahakamcloud/mahakam/pkg/resource_store"
-	"github.com/sirupsen/logrus"
 )
 
 // Handlers holds common modules that each handler needs
@@ -14,6 +19,7 @@ type Handlers struct {
 	Store       store.ResourceStore
 	Network     *network.NetworkManager
 	Provisioner provisioner.Provisioner
+	Client      *client.Mahakam
 	Log         logrus.FieldLogger
 }
 
@@ -31,11 +37,14 @@ func New(config *config.Config, provisioner provisioner.Provisioner, log logrus.
 		return nil
 	}
 
+	mc := mahakamclient.GetMahakamClient(":" + strconv.Itoa(config.MahakamServerConfig.Port))
+
 	return &Handlers{
 		AppConfig:   config,
 		Store:       rs,
 		Network:     n,
 		Provisioner: provisioner,
+		Client:      mc,
 		Log:         log,
 	}
 }


### PR DESCRIPTION
This PR addresses #23 , to simplify mahakam server main function that would load host and port from config.yaml. Handlers registration and app init now done in main function itself.