### PR TITLE
Populate cmd attributes from first arg

### DIFF
--- a/cmd/mahakam/create_app.go
+++ b/cmd/mahakam/create_app.go
@@ -32,9 +32,10 @@ var createAppCmd = &cobra.Command{
 	Short: "Create application",
 	Long:  `Create application on kubernetes cluster with one command`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if cao.Name == "" {
+		if len(args) == 0 {
 			exitWithHelp(cmd, "Please provide name for your application.")
 		}
+		cao.Name = args[0]
 
 		if cao.ClusterName == "" {
 			exitWithHelp(cmd, "Please provide which cluster do you want to run the application.")
@@ -99,7 +100,6 @@ func RunCreateApp(cao *CreateAppOptions) (*models.App, error) {
 
 func init() {
 	// Required flags
-	createAppCmd.Flags().StringVarP(&cao.Name, "app-name", "a", "", "Name for your application")
 	createAppCmd.Flags().StringVarP(&cao.ClusterName, "cluster-name", "c", "", "Name of your kubernetes cluster")
 	createAppCmd.Flags().StringVarP(&cao.ChartURL, "chart", "u", "", "Helm chart url to run your application")
 

--- a/cmd/mahakam/create_cluster.go
+++ b/cmd/mahakam/create_cluster.go
@@ -30,9 +30,10 @@ var createClusterCmd = &cobra.Command{
 	Short: "Create kubernetes cluster",
 	Long:  `Create a kubernetes cluster with one command`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if cco.Name == "" {
+		if len(args) == 0 {
 			exitWithHelp(cmd, "Please provide name for your cluster.")
 		}
+		cco.Name = args[0]
 
 		if cco.Owner == "" {
 			// Hack since we don't have login mechanism yet
@@ -47,10 +48,10 @@ var createClusterCmd = &cobra.Command{
 		}
 
 		fmt.Println("Creating kubernetes cluster...")
-		fmt.Printf("\nName:\t%s", swag.StringValue(res.Name))
-		fmt.Printf("\nCluster Plan:\t%s", res.ClusterPlan)
-		fmt.Printf("\nWorker Nodes:\t%v", res.NumNodes)
-		fmt.Printf("\nStatus:\t%v", res.Status)
+		fmt.Printf("\nName:\t\t%s", swag.StringValue(res.Name))
+		fmt.Printf("\nCluster Plan:\t\t%s", res.ClusterPlan)
+		fmt.Printf("\nWorker Nodes:\t\t%v", res.NumNodes)
+		fmt.Printf("\nStatus:\t\t%v", res.Status)
 		fmt.Printf("\n\nUse 'mahakam describe cluster %s' to monitor the state of your cluster", swag.StringValue(res.Name))
 	},
 }
@@ -71,9 +72,6 @@ func RunCreateCluster(cco *CreateClusterOptions) (*models.Cluster, error) {
 }
 
 func init() {
-	// Required flags
-	createClusterCmd.Flags().StringVarP(&cco.Name, "cluster-name", "c", "", "Name for your kubernetes cluster")
-
 	// Optional flags
 	createClusterCmd.Flags().StringVarP(&cco.Owner, "owner", "o", "", "Owner of your kubernetes cluster")
 	createClusterCmd.Flags().IntVarP(&cco.NumNodes, "num-nodes", "n", 1, "Number of worker nodes you want kubernetes cluster to run")

--- a/cmd/mahakam/describe_cluster.go
+++ b/cmd/mahakam/describe_cluster.go
@@ -23,9 +23,10 @@ var describeClusterCmd = &cobra.Command{
 	Short: "Describe kubernetes cluster",
 	Long:  `Describe a kubernetes cluster with one command`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if dco.Name == "" {
+		if len(args) == 0 {
 			exitWithHelp(cmd, "Please provide name for your cluster.")
 		}
+		dco.Name = args[0]
 
 		res, err := RunDescribeCluster(dco)
 		if err != nil {
@@ -54,8 +55,5 @@ func RunDescribeCluster(dco *DescribeClusterOptions) (*models.Cluster, error) {
 }
 
 func init() {
-	// Required flags
-	describeClusterCmd.Flags().StringVarP(&dco.Name, "cluster-name", "c", "", "Name for your kubernetes cluster")
-
 	describeCmd.AddCommand(describeClusterCmd)
 }

--- a/cmd/mahakam/validate_cluster.go
+++ b/cmd/mahakam/validate_cluster.go
@@ -29,9 +29,10 @@ var validateClusterCmd = &cobra.Command{
 	Short: "Validate kubernetes cluster",
 	Long:  `Validate a kubernetes cluster with one command`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if vco.Name == "" {
+		if len(args) == 0 {
 			exitWithHelp(cmd, "Please provide name for your cluster.")
 		}
+		vco.Name = args[0]
 
 		if vco.Owner == "" {
 			// Hack since we don't have login mechanism yet
@@ -94,9 +95,6 @@ func RunValidateCluster(vco *ValidateClusterOptions) (*models.Cluster, error) {
 }
 
 func init() {
-	// Required flags
-	validateClusterCmd.Flags().StringVarP(&vco.Name, "cluster-name", "c", "", "Name for your kubernetes cluster")
-
 	// Optional flags
 	validateClusterCmd.Flags().StringVarP(&vco.Owner, "owner", "o", "", "Owner of your kubernetes cluster")
 


### PR DESCRIPTION
This PR addresses #57 which removes the need of passing cluster name through `--cluster-name` flag and app name through `--app-name` flag for 4 commands: create cluster, describe cluster, create app, and validate cluster