### PR TITLE
Add make dev and make generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ test: ## run tests
 	@echo running tests...
 	$(GO) test -v $(shell go list -v ./... | grep -v /vendor/ | grep -v integration | grep -v /playground )
 
+.PHONY: dev
+dev: ## run dev server and consul
+	docker-compose -f docker-compose.dev.yaml up --build
+
 .PHONY: dev-server
 dev-server: ## run dev server
 	@echo running dev server...
@@ -59,6 +63,9 @@ dev-docker: ## run dev docker that has terraform libvirt plugin and golang
 staging-docker: ## run staging docker that has terraform libvirt plugin and golang with privileged access
 	@echo running staging docker container...
 	docker run -it --rm --network host --privileged -v $(PWD):/root/go/src/github.com/mahakamcloud/mahakam -v $(HOME)/.aws:/root/.aws -w /root/go/src/github.com/mahakamcloud/mahakam devrunner:latest /bin/bash
+z
+.PHONY: generate
+generate: generate-server generate-client ## Generate both swagger server and client
 
 .PHONY: generate-server
 generate-server: ## Generate swagger server

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ test: ## run tests
 
 .PHONY: dev
 dev: ## run dev server and consul
+	@echo running dev server and consul...
 	docker-compose -f docker-compose.dev.yaml up --build
 
 .PHONY: dev-server
@@ -63,7 +64,7 @@ dev-docker: ## run dev docker that has terraform libvirt plugin and golang
 staging-docker: ## run staging docker that has terraform libvirt plugin and golang with privileged access
 	@echo running staging docker container...
 	docker run -it --rm --network host --privileged -v $(PWD):/root/go/src/github.com/mahakamcloud/mahakam -v $(HOME)/.aws:/root/.aws -w /root/go/src/github.com/mahakamcloud/mahakam devrunner:latest /bin/bash
-z
+
 .PHONY: generate
 generate: generate-server generate-client ## Generate both swagger server and client
 

--- a/README.md
+++ b/README.md
@@ -7,19 +7,15 @@ Running unit test
 $ make test
 ```
 
-Run dev store with consul backend:
+Run dev server and consul with docker-compose:
 ```
-$ make dev-store
+$ make dev
 ```
-
-Run dev server:
-```
-$ make dev-server
-```
+Before running the command, you must populate necessary info in `pkg/config/config.sample.yaml`. Or, you can create new config yaml file and change the volume mount in `docker-compose.dev.yaml` accordingly.
 
 Building mahakam cli as per your machine, find the build under `dist/bin`
 ```
-$ make mahakam-cli
+$ make cli
 ```
 
 Generate mahakam server api using swagger

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -8,6 +8,7 @@ services:
       - "9001:9001"
     volumes:
       - ./pkg/config/example/config.sample.yaml:/etc/mahakam/config.yaml
+      - .:/go/src/github.com/mahakamcloud/mahakam 
     depends_on:
       - consul
   consul:

--- a/pkg/config/example/config.sample.yaml
+++ b/pkg/config/example/config.sample.yaml
@@ -21,7 +21,7 @@ gate:
   gate_nss_api_key: "<TODO: pass nss api key here if gate enabled>"
 terraform:
   libvirt_module_path: "git::https://github.com/mahakamcloud/terraform-libvirt-vm-single?ref=v0.1.1"
-  public_libvirt_module_path: "git::https://github.com/mahakamcloud/terraform-libvirt-vm-double?ref=v0.1.0"
+  public_libvirt_module_path: "git::https://github.com/mahakamcloud/terraform-libvirt-vm-double?ref=v0.1.1"
   image_source_path: "https://cloud-images.ubuntu.com/xenial/20181223/xenial-server-cloudimg-amd64-disk1.img"
 hosts:
   - name: "server01"


### PR DESCRIPTION
Follow PR to #68 as part of #61 , this hooks up docker compose to `make dev` which includes running both mahakam server and consul, by injecting config yaml and the source code for development.